### PR TITLE
logs: try to fix shutdown hook

### DIFF
--- a/tf/init.sh
+++ b/tf/init.sh
@@ -133,13 +133,13 @@ chmod +x $SERVICE
 cat <<SERVICE_DEFINITION > $SERVICE.service
 [Unit]
 Description=
-Before=shutdown.target reboot.target
+Requires=network-online.target
+After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/true
 ExecStop=$SERVICE
-RemainAfterExit=yes
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
While it looks like it works when I log onto a machine and manually stop
the service (i.e. it then runs `ExecStop` and the tarball is uploaded to
S3), it doe snot look like it actually runs when I shut a machine down.
Googling yielded [this][0], which I'm trying here.

[0]: https://askubuntu.com/questions/1449198/running-a-script-at-shutdown-before-networking-goes-down